### PR TITLE
Enable reading time display on blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -136,6 +136,7 @@ defaults:
       layout: post
       comments: false
       toc: true
+      show_reading_time: true
       permalink: /posts/:title/
   - scope:
       path: _drafts


### PR DESCRIPTION
Adds show_reading_time: true to post defaults in _config.yml so all
posts display estimated reading time via Chirpy's built-in support.

https://claude.ai/code/session_01KqxhoEoUduDWdnTGYGHEac